### PR TITLE
bump:rust to 1.71.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70.0
+FROM rust:1.71.0
 
 LABEL "com.github.actions.name"="Rust Action Box"
 LABEL "com.github.actions.description"="'Silverbullet' for a quickstart Rust CI based upon Github Actions"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 'Silverbullet' for a quickstart Rust CI based upon [Github Actions](https://developer.github.com/actions/)
 
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org) [![](https://img.shields.io/badge/Rust-1.70.0-orange)](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org) [![](https://img.shields.io/badge/Rust-1.71.0-orange)](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html)
 
 *What's inside the "box":*
 
-* Rust 1.70.0
+* Rust 1.71.0
 * Rustfmt
 * Clippy
 * Cargo Release


### PR DESCRIPTION
Since 13 July, the [next minor version of Rust, `.1.71.0`](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html), is available. In this PR, I bump the version of the used Docker image and update the icon in the README.