### PR TITLE
ci: run integration tests with code changes before releasing new action

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,23 @@
+name: Integration test for new action version
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  it:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Verify that Docker image can be built
+        run: |
+          docker build .
+      - name: Run tests of subdir `integration-test`
+        uses: ./
+        with:
+          args: |
+            cargo fmt --manifest-path integration-test/Cargo.toml -- --check \
+                && cargo clippy --manifest-path integration-test/Cargo.toml -- -Dwarnings \
+                && cargo test --manifest-path integration-test/Cargo.toml


### PR DESCRIPTION
This GH Action workflow runs integration tests on `push` and `pull_request` with the latest code of this `rust-action`. It does require neither a release nor a push to master to test the latest changes in this action. This workflow can be used as required test for a branch protection rule.